### PR TITLE
Downsampling fixed and adding scores file

### DIFF
--- a/cryoassess/lib/imgprep.py
+++ b/cryoassess/lib/imgprep.py
@@ -45,7 +45,7 @@ def scaleImage(img, height=494):
     '''
     Downsample image, scale the pixel value from 0-255 and save it as the Image object.
     '''
-    new_img = downsample(img, height)
+    img = downsample(img, height)
     new_img = ((img-img.min())/((img.max()-img.min())+1e-7)*255).astype('uint8')
     new_img = Image.fromarray(new_img)
     new_img = new_img.convert("L")

--- a/cryoassess/micassess.py
+++ b/cryoassess/micassess.py
@@ -122,7 +122,6 @@ def predict(args):
             micName = sorted(glob.glob(os.path.join('MicAssess', 'jpgs', 'data', '*.jpg')))[i]
             f.write('{}\t{}\n'.format(micName.split('/')[-1], prob[i][0]))
 
-
     good_idx = np.where(prob > args['threshold'])[0]
     bad_idx = np.where(prob <= args['threshold'])[0]
 

--- a/cryoassess/micassess.py
+++ b/cryoassess/micassess.py
@@ -116,6 +116,13 @@ def predict(args):
     os.mkdir(os.path.join('MicAssess', 'predGood'))
     os.mkdir(os.path.join('MicAssess', 'predBad'))
 
+    probsFile = 'probs.tsv'
+    with open(probsFile, 'w') as f:
+        for i in range(len(prob)):
+            micName = sorted(glob.glob(os.path.join('MicAssess', 'jpgs', 'data', '*.jpg')))[i]
+            f.write('{}\t{}\n'.format(micName.split('/')[-1], prob[i][0]))
+
+
     good_idx = np.where(prob > args['threshold'])[0]
     bad_idx = np.where(prob <= args['threshold'])[0]
 


### PR DESCRIPTION
The proposed pull request corrects scaleImage function in imgprep.py file, as the scaled imaged was not the downsampled but the original.

Also, we propose the micassess.py script to write a scores file to be able to check the micrographs' scores, enabling the user to make possible changes in the threshold with no need of running the script again.